### PR TITLE
feat: Enter to send reply, Escape to cancel (#14)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1443,8 +1443,8 @@ function connectSSE(userId) {
                     return `<button class="action-button" id="reply-btn-${nid}-${i}" onclick="toggleReply('${nid}', '${i}')">↩ ${ph}</button>
                         <div class="reply-row" id="reply-row-${nid}-${i}">
                             <input type="text" class="reply-input" id="reply-input-${nid}-${i}" placeholder="${ph}"
-                                   onkeydown="if(event.key==='Enter') handleAction('${nid}', '${key}', this.value)">
-                            <button class="action-button" onclick="handleAction('${nid}', '${key}', document.getElementById('reply-input-${nid}-${i}').value)">Send</button>
+                                   onkeydown="if(event.key==='Enter'&&this.value.trim()){submitReply('${nid}','${key}',this,'${i}')}else if(event.key==='Escape'){toggleReply('${nid}','${i}')}">
+                            <button class="action-button" onclick="submitReply('${nid}', '${key}', document.getElementById('reply-input-${nid}-${i}'), '${i}')">Send</button>
                         </div>`;
                 }
                 const icon  = SEMANTIC_ICONS[action.semanticAction] || '';
@@ -1462,6 +1462,17 @@ function connectSSE(userId) {
             const row = document.getElementById(`reply-row-${nid}-${idx}`);
             const isOpen = row.classList.toggle('open');
             if (isOpen) row.querySelector('input').focus();
+            else row.querySelector('input').value = '';
+        }
+
+        function submitReply(nid, key, inputEl, idx) {
+            const value = inputEl.value.trim();
+            if (!value) return;
+            // Give immediate visual feedback: close the row before the SSE round-trip
+            inputEl.value = '';
+            const row = document.getElementById(`reply-row-${nid}-${idx}`);
+            if (row) row.classList.remove('open');
+            handleAction(nid, key, value);
         }
 
         function escapeHtml(str) {


### PR DESCRIPTION
## Summary

Fixes #14 — pressing **Enter** in a notification's reply input now sends the reply without needing the mouse.

## Changes

- **Enter** submits the reply (only when the input is non-empty, to prevent accidental blank sends)
- **Escape** closes and clears the reply row without sending
- Closing the reply row by clicking the action button again also clears the input
- Extracted a `submitReply()` helper that immediately closes the input row for instant visual feedback, rather than waiting for the SSE round-trip before the UI updates