### PR TITLE
fix: restore action button when server errors or SSE is broken

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1730,12 +1730,19 @@ function connectSSE(userId) {
             const el = document.getElementById(`notification-${notificationId}`);
             if (el) el.classList.add('notification-pending');
             try {
-                await fetch(`/api/notifications/${notificationId}/actions`, {
+                const res = await fetch(`/api/notifications/${notificationId}/actions`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ action: actionType, response, userId: currentUser.userId })
                 });
-                // Let the backend decide removal via SSE; restore on failure only
+                if (!res.ok) {
+                    console.error('Action failed:', res.status, await res.text().catch(() => ''));
+                    if (el) el.classList.remove('notification-pending');
+                    return;
+                }
+                // SSE update will rebuild the card; fall back to clearing pending after 30 s
+                // in case the SSE connection is broken.
+                setTimeout(() => { if (el) el.classList.remove('notification-pending'); }, 30000);
             } catch (error) {
                 console.error('Error handling action:', error);
                 if (el) el.classList.remove('notification-pending');


### PR DESCRIPTION
## Summary

- `handleAction()` now checks `res.ok` after the fetch — on a non-2xx response the `notification-pending` class is removed immediately so the user can retry
- Adds a 30-second fallback `setTimeout` after a successful POST to clear the pending state if the SSE connection is broken and no re-render ever arrives (normal SSE path is unchanged)

## Root cause

The `catch` block only fires on network-level failures. HTTP errors (404, 500, etc.) were silently swallowed, leaving the button greyed out with `pointer-events: none` indefinitely.

## Test plan

- [ ] **Happy path** — click an action button; button greys out briefly, then card disappears after SSE arrives
- [ ] **HTTP error** — temporarily inject `return res.status(500)` in the actions endpoint; clicking an action should grey the button then immediately restore it
- [ ] **Broken SSE** — block the `/api/notifications/stream` request in DevTools; click an action; button should restore after ~30 seconds

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)