### PR TITLE
fix: show pending state until Android acknowledges action dispatch

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1342,8 +1342,9 @@ function connectSSE(userId) {
         function renderNotificationCard(notification, newIds, isFilteredPreview = false) {
             const isNew = newIds.has(notification.id);
             const isSilent = notification.isSilent === true;
+            const isPending = notification.actionTaken && !notification.actionDispatched;
             return `
-                <div class="notification${isNew ? ' notification-new' : ''}${isSilent ? ' notification-silent' : ''}${isFilteredPreview ? ' notification-filtered-preview' : ''}"
+                <div class="notification${isNew ? ' notification-new' : ''}${isSilent ? ' notification-silent' : ''}${isFilteredPreview ? ' notification-filtered-preview' : ''}${isPending ? ' notification-pending' : ''}"
                      id="notification-${notification.id}">
                     ${notification.icon ? `<img class="notification-icon" src="${notification.icon}" alt="" onerror="this.style.display='none'">` : ''}
                     ${!isFilteredPreview ? `<button class="close-button" onclick="dismissNotification('${notification.id}')" title="Dismiss">&#x2715;</button>` : ''}
@@ -1442,8 +1443,11 @@ function connectSSE(userId) {
         }
 
         function renderSentAction(notification) {
-            const { actionTaken, actionResponse } = notification;
+            const { actionTaken, actionResponse, actionDispatched } = notification;
             if (!actionTaken) return '';
+            if (!actionDispatched) {
+                return `<div class="sent-reply"><div class="sent-reply-bubble"><span class="sent-reply-label">⏳ Sending to device…</span></div></div>`;
+            }
             const icon = SEMANTIC_ICONS[actionTaken] ?? '';
             if (actionResponse) {
                 return `<div class="sent-reply"><div class="sent-reply-bubble"><span class="sent-reply-label">↩ You replied</span>${escapeHtml(actionResponse)}</div></div>`;

--- a/server.js
+++ b/server.js
@@ -744,6 +744,13 @@ app.post('/api/notifications/:id/actions', requireUserId, (req, res) => {
   if (response != null) fcmPayload.actionResponse = String(response);
   sendFcmDataMessages(userId, fcmPayload)
     .catch(e => console.error('FCM action error:', e.message));
+  // Auto-confirm after 30 s if the Android device never calls /dispatched (e.g. offline)
+  setTimeout(() => {
+    if (notification.actionTaken && !notification.actionDispatched) {
+      notification.actionDispatched = true;
+      broadcastToUser(userId, 'update', { reason: 'action', id });
+    }
+  }, 30000);
   res.status(200).json({ success: true });
 });
 


### PR DESCRIPTION
Fixes #26.

## Summary

- **`server.js`**: After sending the FCM action message, schedules a 30-second fallback that auto-sets `actionDispatched = true` and re-broadcasts the SSE update if Android never calls `/dispatched` (e.g. device is offline). This unblocks deletion and resolves the pending UI state gracefully.
- **`renderNotificationCard`** (`index.html`): Applies `notification-pending` class when `actionTaken && !actionDispatched`, so the dimmed/blocked state persists across SSE-triggered re-renders — not just during the initial fetch.
- **`renderSentAction`** (`index.html`): Shows `⏳ Sending to device…` while waiting for the Android ack; only shows `✓ Action taken` / `↩ You replied` once `actionDispatched` is true.

## Test plan

- [ ] Click an action button — card should dim and show "⏳ Sending to device…" immediately
- [ ] Have Android call `POST /api/notifications/:id/actions/dispatched` — card should update to "✓ Action taken" and un-dim
- [ ] Offline test: do not call `/dispatched`; after 30 s the card should auto-confirm and become dismissible
- [ ] Error path: if the POST to `/actions` fails, card should un-dim and buttons should reappear (existing behaviour, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)