### PR TITLE
fix: rate limiting on auth endpoints + stronger reset token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "body-parser": "^1.20.4",
         "cors": "^2.8.6",
         "express": "^4.22.1",
+        "express-rate-limit": "^8.3.2",
         "firebase-admin": "^13.8.0",
         "nodemailer": "^8.0.5",
         "sqlite3": "^6.0.1",
@@ -1302,6 +1303,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2092,7 +2111,6 @@
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
       "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">= 12"
       }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "body-parser": "^1.20.4",
     "cors": "^2.8.6",
     "express": "^4.22.1",
+    "express-rate-limit": "^8.3.2",
     "firebase-admin": "^13.8.0",
     "nodemailer": "^8.0.5",
     "sqlite3": "^6.0.1",

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const cors = require('cors');
 const path = require('path');
 const crypto = require('crypto');
 const nodemailer = require('nodemailer');
+const rateLimit = require('express-rate-limit');
 
 // Load secrets (SMTP config, etc.)
 let secrets = {};
@@ -119,6 +120,31 @@ app.use(cors());
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(express.static('public'));
+
+// Rate limiters for auth endpoints
+const authLoginLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, error: 'Too many attempts, please try again later.' }
+});
+
+const authResetRequestLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, error: 'Too many reset requests, please try again later.' }
+});
+
+const authResetConfirmLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { success: false, error: 'Too many attempts, please try again later.' }
+});
 
 // Initialize SQLite database
 const db = new sqlite3.Database(process.env.DB_PATH || './notifications.db', (err) => {
@@ -777,7 +803,7 @@ app.post('/api/notifications/:id/actions/dispatched', requireUserId, (req, res) 
 // User management API endpoints
 
 // Unified auth: register (new user) or login (existing user)
-app.post('/api/auth', async (req, res) => {
+app.post('/api/auth', authLoginLimiter, async (req, res) => {
   const { password, email } = req.body;
   const username = normalizeUsername(req.body.username);
   if (!username || !password) {
@@ -823,7 +849,7 @@ app.post('/api/auth', async (req, res) => {
 });
 
 // POST /api/auth/reset-request — send a time-limited reset code to the user's email
-app.post('/api/auth/reset-request', (req, res) => {
+app.post('/api/auth/reset-request', authResetRequestLimiter, (req, res) => {
   const username = normalizeUsername(req.body.username);
   if (!username) return res.status(400).json({ success: false, error: 'username is required' });
 
@@ -834,7 +860,7 @@ app.post('/api/auth/reset-request', (req, res) => {
       return res.status(200).json({ success: true, message: 'If an account with an email exists, a code has been sent.' });
     }
 
-    const code = Math.floor(100000 + Math.random() * 900000).toString(); // 6-digit
+    const code = crypto.randomBytes(32).toString('hex');
     const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString(); // 15 minutes
 
     // Remove any existing codes for this user, then insert new one
@@ -868,7 +894,7 @@ app.post('/api/auth/reset-request', (req, res) => {
 });
 
 // POST /api/auth/reset-confirm — verify code and recreate the account with a new password
-app.post('/api/auth/reset-confirm', (req, res) => {
+app.post('/api/auth/reset-confirm', authResetConfirmLimiter, (req, res) => {
   const { code, newPassword } = req.body;
   if (!code || !newPassword) {
     return res.status(400).json({ success: false, error: 'code and newPassword are required' });


### PR DESCRIPTION
## Summary

Closes #29.

- Added `express-rate-limit` middleware to all three auth endpoints to block brute-force attacks
- Replaced the weak 6-digit `Math.random()` reset code with a 256-bit cryptographically secure token (`crypto.randomBytes(32).hex`)

### Rate limits applied

| Endpoint | Window | Max requests per IP |
|---|---|---|
| `POST /api/auth` | 15 min | 10 |
| `POST /api/auth/reset-request` | 1 hour | 5 |
| `POST /api/auth/reset-confirm` | 15 min | 10 |

The tighter limit on `reset-request` also prevents the endpoint from being used to spam users with reset emails.

## Test plan

- [ ] Login/register fails with 429 after 10 rapid requests from the same IP within 15 min
- [ ] `reset-request` returns 429 after 5 requests within an hour
- [ ] `reset-confirm` returns 429 after 10 rapid attempts within 15 min
- [ ] Successful login/register still works within the rate limit window
- [ ] Reset flow still works end-to-end (request code → confirm with token → new account created)
- [ ] Rate limit headers (`RateLimit-*`) are present in responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)